### PR TITLE
Migrate the function app to the .NET 8 isolated worker

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,9 @@ on:
     - master
 env:
   AZURE_FUNCTIONAPP_NAME: NantoNBaiFunctionW
-  AZURE_FUNCTIONAPP_PACKAGE_PATH: NantoNBaiFunction
+  # 発行先はソースディレクトリと分ける。
+  # 同一にすると *.cs や obj/ ごとデプロイパッケージに含まれてしまう。
+  AZURE_FUNCTIONAPP_PACKAGE_PATH: functionapp
   CONFIGURATION: Release
   DOTNET_CORE_VERSION: 8.0.x
   WORKING_DIRECTORY: NantoNBaiFunction
@@ -24,6 +26,24 @@ jobs:
       run: dotnet build "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --arch x64 --no-restore
     - name: Publish
       run: dotnet publish "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --arch x64 --no-build --output "${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}"
+    - name: Verify publish output
+      shell: pwsh
+      env:
+        PUBLISH_DIR: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
+      run: |
+        $required = @(
+          'host.json',
+          'worker.config.json',
+          'functions.metadata',
+          'NantoNBaiFunction.dll',
+          'nanto-n-bai-template.pptx',
+          'nanto-n-bai-template(1).pptx'
+        )
+        $missing = @($required | Where-Object { -not (Test-Path (Join-Path $env:PUBLISH_DIR $_)) })
+        if ($missing.Count -gt 0) {
+          throw "発行成果物に不足がある: $($missing -join ', ')"
+        }
+        Write-Host '発行成果物の確認 OK'
     - name: Publish Artifacts
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
@@ -35,6 +55,7 @@ jobs:
     permissions:
       id-token: write #This is required for requesting the JWT
     steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: Login to Azure
       uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
       with:
@@ -51,4 +72,10 @@ jobs:
       with:
         app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
         package: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
-
+    # E2E は CD の完了後に別ワークフローで走るため、
+    # ここで最低限の疎通を確認して壊れたデプロイを早く赤くする。
+    - name: Smoke test deployed app
+      shell: pwsh
+      env:
+        APP_NAME: ${{ env.AZURE_FUNCTIONAPP_NAME }}
+      run: pwsh -File ./scripts/Invoke-SmokeTest.ps1 -BaseUrl "https://$($env:APP_NAME.ToLowerInvariant()).azurewebsites.net"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,76 @@ jobs:
       with:
         name: ci-result
         path: NantoNBaiTests/bin
+
+  # 分離ワーカーとして実際に Functions ホストを起動し、全エンドポイントの疎通を確認する。
+  # ユニットテストは NantoNBai ライブラリしか触らないため、
+  # ワーカープロセス内でのテンプレート解決・画像変換・OpenAPI はここでしか検証できない。
+  smoke:
+    name: Function app smoke test
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - name: Setup .NET
+      uses: actions/setup-dotnet@baa11fbfe1d6520db94683bd5c7a3818018e4309 # v5
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+    - name: Publish function app
+      run: dotnet publish NantoNBaiFunction/NantoNBaiFunction.csproj --configuration Release --arch x64 --output ${{ runner.temp }}/functionapp
+    - name: Verify publish output
+      shell: pwsh
+      env:
+        PUBLISH_DIR: ${{ runner.temp }}/functionapp
+      run: |
+        $required = @(
+          'host.json',
+          'worker.config.json',
+          'functions.metadata',
+          'NantoNBaiFunction.dll',
+          'nanto-n-bai-template.pptx',
+          'nanto-n-bai-template(1).pptx'
+        )
+        $missing = @($required | Where-Object { -not (Test-Path (Join-Path $env:PUBLISH_DIR $_)) })
+        if ($missing.Count -gt 0) {
+          throw "発行成果物に不足がある: $($missing -join ', ')"
+        }
+        Write-Host '発行成果物の確認 OK'
+    - name: Ensure Azure Functions Core Tools
+      shell: pwsh
+      run: |
+        if (-not (Get-Command func -ErrorAction SilentlyContinue)) {
+          npm install -g azure-functions-core-tools@4 --unsafe-perm true
+        }
+        func --version
+    - name: Start Functions host
+      shell: pwsh
+      env:
+        PUBLISH_DIR: ${{ runner.temp }}/functionapp
+        FUNC_LOG: ${{ runner.temp }}/func.log
+      run: |
+        @{
+          IsEncrypted = $false
+          Values = @{
+            AzureWebJobsStorage = ''
+            FUNCTIONS_WORKER_RUNTIME = 'dotnet-isolated'
+          }
+        } | ConvertTo-Json | Set-Content -Path (Join-Path $env:PUBLISH_DIR 'local.settings.json') -Encoding utf8
+
+        # func は .exe だったり npm の .cmd シムだったりするので cmd 経由で起動する
+        Start-Process -FilePath 'cmd.exe' `
+          -ArgumentList '/c', "func start --port 7071 > `"$env:FUNC_LOG`" 2>&1" `
+          -WorkingDirectory $env:PUBLISH_DIR `
+          -WindowStyle Hidden
+    - name: Smoke test
+      shell: pwsh
+      run: pwsh -File ./scripts/Invoke-SmokeTest.ps1 -BaseUrl http://127.0.0.1:7071
+    - name: Functions host log
+      if: always()
+      shell: pwsh
+      env:
+        FUNC_LOG: ${{ runner.temp }}/func.log
+      run: |
+        if (Test-Path $env:FUNC_LOG) {
+          Get-Content $env:FUNC_LOG -Tail 300
+        } else {
+          Write-Host 'Functions ホストのログがない'
+        }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,13 +60,36 @@ jobs:
           throw "発行成果物に不足がある: $($missing -join ', ')"
         }
         Write-Host '発行成果物の確認 OK'
-    - name: Ensure Azure Functions Core Tools
+    - name: Install Azure Functions Core Tools
       shell: pwsh
+      env:
+        FUNC_DIR: ${{ runner.temp }}/func-cli
       run: |
-        if (-not (Get-Command func -ErrorAction SilentlyContinue)) {
-          npm install -g azure-functions-core-tools@4 --unsafe-perm true
+        $ErrorActionPreference = 'Stop'
+        $ProgressPreference = 'SilentlyContinue'
+
+        # windows-latest に func は入っておらず、npm レジストリにも依存したくないので
+        # 公式のリリースフィードから取得してハッシュを検証する
+        $feed = Invoke-RestMethod -Uri 'https://cdn.functions.azure.com/public/cli-feed-v4.json' -TimeoutSec 120
+        $tag = $feed.tags.v4.release
+        $release = ($feed.releases.PSObject.Properties | Where-Object { $_.Name -eq $tag }).Value
+        if (-not $release) { throw "リリースフィードに $tag が無い" }
+
+        $artifact = @($release.coreTools | Where-Object { $_.OS -eq 'Windows' -and $_.Architecture -eq 'x64' })[0]
+        if (-not $artifact) { throw 'Windows x64 の Core Tools がリリースフィードに無い' }
+        Write-Host "Core Tools $tag : $($artifact.downloadLink)"
+
+        $zip = Join-Path $env:RUNNER_TEMP 'func-cli.zip'
+        Invoke-WebRequest -Uri $artifact.downloadLink -OutFile $zip -TimeoutSec 900
+
+        $actual = (Get-FileHash -Path $zip -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($actual -ne $artifact.sha2.ToLowerInvariant()) {
+          throw "Core Tools のハッシュが一致しない: expected=$($artifact.sha2) actual=$actual"
         }
-        func --version
+
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($zip, $env:FUNC_DIR)
+        $env:FUNC_DIR | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+        & (Join-Path $env:FUNC_DIR 'func.exe') --version
     - name: Start Functions host
       shell: pwsh
       env:

--- a/.github/workflows/migrate-to-isolated.yml
+++ b/.github/workflows/migrate-to-isolated.yml
@@ -1,0 +1,150 @@
+# in-process モデルから分離ワーカーへの切り替えを行う一度きりのワークフロー。
+#
+# FUNCTIONS_WORKER_RUNTIME (ランタイム) とデプロイパッケージ (ペイロード) は
+# 同時に入れ替わらなければならない。本番に直接適用すると、
+# 設定変更→再起動→デプロイ完了までの間ランタイムとペイロードが不整合になり、
+# デプロイに失敗した場合は起動不能のまま戻せなくなる。
+#
+# そのためデプロイスロットに新構成を載せ、疎通確認に成功してからスワップする。
+# スワップ対象外に指定していないアプリケーション設定はスロットと一緒に移動するので、
+# ランタイム設定とペイロードが同時に本番へ入れ替わる。
+#
+# 参考: https://azure.github.io/jpazpaas/2024/08/30/migrate-azure-functions-inprocess-to-isolated-using-slot.html
+name: Migrate to isolated worker
+
+on:
+  workflow_dispatch:
+    inputs:
+      resource_group:
+        description: 'Function App のリソースグループ名'
+        required: true
+        type: string
+      slot:
+        description: '検証に使うデプロイスロット名'
+        required: true
+        default: staging
+        type: string
+      swap:
+        description: '疎通確認に成功したらスロットを本番とスワップする'
+        required: true
+        default: false
+        type: boolean
+
+env:
+  AZURE_FUNCTIONAPP_NAME: NantoNBaiFunctionW
+  AZURE_FUNCTIONAPP_PACKAGE_PATH: functionapp
+  CONFIGURATION: Release
+  DOTNET_CORE_VERSION: 8.0.x
+  WORKING_DIRECTORY: NantoNBaiFunction
+
+jobs:
+  migrate:
+    runs-on: windows-latest
+    permissions:
+      id-token: write
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@baa11fbfe1d6520db94683bd5c7a3818018e4309 # v5
+      with:
+        dotnet-version: ${{ env.DOTNET_CORE_VERSION }}
+    - name: Publish
+      run: dotnet publish "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --arch x64 --output "${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}"
+
+    - name: Login to Azure
+      uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
+      with:
+        client-id: ${{ secrets.__clientidsecretname__ }}
+        tenant-id: ${{ secrets.__tenantidsecretname__ }}
+        subscription-id: ${{ secrets.__subscriptionidsecretname__ }}
+
+    - name: Ensure deployment slot
+      shell: pwsh
+      env:
+        APP_NAME: ${{ env.AZURE_FUNCTIONAPP_NAME }}
+        RESOURCE_GROUP: ${{ inputs.resource_group }}
+        SLOT: ${{ inputs.slot }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $slots = az functionapp deployment slot list --name $env:APP_NAME --resource-group $env:RESOURCE_GROUP --query '[].name' --output tsv
+        if ($LASTEXITCODE -ne 0) { throw 'デプロイスロットの一覧取得に失敗した' }
+        $existing = @($slots -split "`n" | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+        if ($existing -contains $env:SLOT) {
+          Write-Host "スロット '$($env:SLOT)' は既に存在する"
+        } else {
+          Write-Host "スロット '$($env:SLOT)' を作成する"
+          az functionapp deployment slot create --name $env:APP_NAME --resource-group $env:RESOURCE_GROUP --slot $env:SLOT
+          if ($LASTEXITCODE -ne 0) { throw 'デプロイスロットの作成に失敗した' }
+        }
+
+    - name: Configure slot for the isolated worker
+      shell: pwsh
+      env:
+        APP_NAME: ${{ env.AZURE_FUNCTIONAPP_NAME }}
+        RESOURCE_GROUP: ${{ inputs.resource_group }}
+        SLOT: ${{ inputs.slot }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        az functionapp config appsettings set `
+          --name $env:APP_NAME --resource-group $env:RESOURCE_GROUP --slot $env:SLOT `
+          --settings FUNCTIONS_WORKER_RUNTIME=dotnet-isolated --output none
+        if ($LASTEXITCODE -ne 0) { throw 'FUNCTIONS_WORKER_RUNTIME の設定に失敗した' }
+
+        # .NET 8 の in-process モデルを有効化する設定。分離ワーカーでは不要で、
+        # 残したままにすると挙動が未定義になるため削除する。
+        $names = az functionapp config appsettings list `
+          --name $env:APP_NAME --resource-group $env:RESOURCE_GROUP --slot $env:SLOT `
+          --query '[].name' --output tsv
+        if ($LASTEXITCODE -ne 0) { throw 'アプリケーション設定の一覧取得に失敗した' }
+        if (@($names -split "`n" | ForEach-Object { $_.Trim() }) -contains 'FUNCTIONS_INPROC_NET8_ENABLED') {
+          az functionapp config appsettings delete `
+            --name $env:APP_NAME --resource-group $env:RESOURCE_GROUP --slot $env:SLOT `
+            --setting-names FUNCTIONS_INPROC_NET8_ENABLED --output none
+          if ($LASTEXITCODE -ne 0) { throw 'FUNCTIONS_INPROC_NET8_ENABLED の削除に失敗した' }
+          Write-Host 'FUNCTIONS_INPROC_NET8_ENABLED を削除した'
+        } else {
+          Write-Host 'FUNCTIONS_INPROC_NET8_ENABLED は設定されていない'
+        }
+
+    - name: Deploy to slot
+      uses: Azure/functions-action@0bd707f87c0b6385742bab336c74e1afc61f6369 # v1
+      with:
+        app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
+        slot-name: ${{ inputs.slot }}
+        package: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
+
+    - name: Smoke test slot
+      shell: pwsh
+      env:
+        APP_NAME: ${{ env.AZURE_FUNCTIONAPP_NAME }}
+        RESOURCE_GROUP: ${{ inputs.resource_group }}
+        SLOT: ${{ inputs.slot }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $slotHost = az functionapp show `
+          --name $env:APP_NAME --resource-group $env:RESOURCE_GROUP --slot $env:SLOT `
+          --query defaultHostName --output tsv
+        if ($LASTEXITCODE -ne 0 -or -not $slotHost) { throw 'スロットのホスト名を取得できなかった' }
+        Write-Host "スロットのホスト名: $slotHost"
+        pwsh -File ./scripts/Invoke-SmokeTest.ps1 -BaseUrl "https://$($slotHost.Trim())"
+
+    - name: Swap slot into production
+      if: ${{ inputs.swap }}
+      shell: pwsh
+      env:
+        APP_NAME: ${{ env.AZURE_FUNCTIONAPP_NAME }}
+        RESOURCE_GROUP: ${{ inputs.resource_group }}
+        SLOT: ${{ inputs.slot }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        az functionapp deployment slot swap `
+          --name $env:APP_NAME --resource-group $env:RESOURCE_GROUP `
+          --slot $env:SLOT --target-slot production --output none
+        if ($LASTEXITCODE -ne 0) { throw 'スロットのスワップに失敗した' }
+
+    - name: Smoke test production
+      if: ${{ inputs.swap }}
+      shell: pwsh
+      env:
+        APP_NAME: ${{ env.AZURE_FUNCTIONAPP_NAME }}
+      run: pwsh -File ./scripts/Invoke-SmokeTest.ps1 -BaseUrl "https://$($env:APP_NAME.ToLowerInvariant()).azurewebsites.net"

--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,5 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+# CD/CI がここに Function App を発行する
+/functionapp/

--- a/E2ETest/TestProduction.cs
+++ b/E2ETest/TestProduction.cs
@@ -1,5 +1,6 @@
 ﻿using Codeuctivity.ImageSharpCompare;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using SixLabors.ImageSharp;
 
 namespace E2ETest
@@ -7,11 +8,13 @@ namespace E2ETest
     [TestClass]
     public class TestProduction : PageTest
     {
+        private const string BaseUrl = "https://nantonbaifunctionw.azurewebsites.net";
+
         [TestMethod]
         public async Task GenerateOnFunctionApp()
         {
             // https://n-bai.koudenpa.dev/api/Viewer?name=ポート番号&from=80&to=443
-            var res = await Page.GotoAsync("https://nantonbaifunctionw.azurewebsites.net/api/Generate.png?name=ポート番号&from=80&to=443");
+            var res = await Page.GotoAsync($"{BaseUrl}/api/Generate.png?name=ポート番号&from=80&to=443");
 
             Console.WriteLine(JsonConvert.SerializeObject(res, new JsonSerializerSettings
             {
@@ -28,6 +31,27 @@ namespace E2ETest
             var calcDiff = ImageSharpCompare.CalcDiff(actualImage, expectedImage);
 
             Assert.AreEqual(0, calcDiff.PixelErrorCount);
+        }
+
+        /// <summary>
+        /// OpenAPI ドキュメントは README と Index から公開リンクとして案内している。
+        /// 分離ワーカー移行で最も壊れやすい箇所なので E2E でも監視する。
+        /// </summary>
+        [TestMethod]
+        public async Task SwaggerDocumentOnFunctionApp()
+        {
+            var res = await Page.GotoAsync($"{BaseUrl}/api/swagger.json");
+
+            Assert.IsNotNull(res);
+            Assert.AreEqual(200, res.Status);
+
+            var document = JObject.Parse(await res.TextAsync());
+            var paths = document["paths"] as JObject;
+
+            Assert.IsNotNull(paths, "swagger.json に paths がない");
+            var pathNames = paths.Properties().Select(x => x.Name).ToList();
+            CollectionAssert.Contains(pathNames, "/Generate.{format}");
+            CollectionAssert.Contains(pathNames, "/Viewer");
         }
     }
 }

--- a/NantoNBaiFunction/NantoNBaiFunction.cs
+++ b/NantoNBaiFunction/NantoNBaiFunction.cs
@@ -1,7 +1,5 @@
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Azure.WebJobs;
-using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
@@ -12,23 +10,39 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
+using System.Web;
 
 namespace NantoNBaiFunction
 {
     public class NantoNBaiFunction
     {
+        private const string CacheControl = "public, max-age=31536000";
+
+        // in-process では ExecutionContext.FunctionAppDirectory (host.json のあるディレクトリ) を渡していた。
+        // 分離ワーカーではワーカーアセンブリが発行ルートに直接置かれるため、
+        // AppContext.BaseDirectory が同じディレクトリを指す。
+        // テンプレート pptx は NantoNBai.csproj が CopyToOutputDirectory=Always で
+        // このディレクトリに配置している。
+        private static readonly string TemplateDirectory = AppContext.BaseDirectory;
+
         private readonly ILogger<NantoNBaiFunction> _logger;
         private readonly INantoNBaiService _nantoNBaiService;
         private readonly Converter _converter;
+        private readonly Formatter _formatter;
 
-        public NantoNBaiFunction(ILogger<NantoNBaiFunction> log)
+        public NantoNBaiFunction(
+            ILogger<NantoNBaiFunction> log,
+            INantoNBaiService nantoNBaiService,
+            Converter converter,
+            Formatter formatter)
         {
             _logger = log;
-            _nantoNBaiService = new NantoNBaiShapeCrawler();
-            _converter = new Converter();
+            _nantoNBaiService = nantoNBaiService;
+            _converter = converter;
+            _formatter = formatter;
         }
 
-        [FunctionName(nameof(Generate))]
+        [Function(nameof(Generate))]
         [OpenApiOperation("Generate", "Gurafu")]
         [OpenApiParameter(name: "name", In = ParameterLocation.Query, Required = true, Type = typeof(string), Description = "The **Name** parameter")]
         [OpenApiParameter(name: "from", In = ParameterLocation.Query, Required = true, Type = typeof(double), Description = "The **From** parameter")]
@@ -36,90 +50,98 @@ namespace NantoNBaiFunction
         [OpenApiParameter(name: "nan", In = ParameterLocation.Query, Required = false, Type = typeof(Nan), Description = "The **Nan** parameter")]
         [OpenApiParameter(name: "format", In = ParameterLocation.Path, Required = true, Type = typeof(ConvertFormat), Description = "The **Format** parameter")]
         [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/octet-stream", bodyType: typeof(byte[]))]
-        public async Task<IActionResult> Generate(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "Generate.{format}")] HttpRequest req,
-            string format,
-            ExecutionContext executionContext
+        public async Task<HttpResponseData> Generate(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "Generate.{format}")] HttpRequestData req,
+            string format
         )
         {
-            _logger.LogInformation($"C# HTTP trigger function processed a request. path: {req.Path}, query: {req.QueryString}");
+            _logger.LogInformation("C# HTTP trigger function processed a request. path: {Path}, query: {Query}", req.Url.AbsolutePath, req.Url.Query);
 
-            string name = req.Query["name"];
-            var from = double.Parse(req.Query["from"]);
-            var to = double.Parse(req.Query["to"]);
+            var query = HttpUtility.ParseQueryString(req.Url.Query);
+            string name = query["name"];
+            var from = double.Parse(query["from"]);
+            var to = double.Parse(query["to"]);
             var convertFormat = (ConvertFormat)System.Enum.Parse(typeof(ConvertFormat), format, true);
-            var nan = (Nan)System.Enum.Parse(typeof(Nan), req.Query["nan"].FirstOrDefault() ?? "bai", true);
+            var nan = (Nan)System.Enum.Parse(typeof(Nan), query["nan"] ?? "bai", true);
 
             var ms = _nantoNBaiService.Generate(
-                executionContext.FunctionAppDirectory,
+                TemplateDirectory,
                 name,
-                from, 
-                to, 
+                from,
+                to,
                 nan,
                 "application/vnd.openxmlformats-officedocument.presentationml.presentation");
 
             if (convertFormat != ConvertFormat.Pptx)
             {
-                var imageFileStream = _converter.ConvertFromPptx(ms, convertFormat);
+                using var imageFileStream = _converter.ConvertFromPptx(ms, convertFormat);
                 ms.Dispose();
-                // XXX MemoryStream が返ってくることは知ってるけれどなー。byte[]返却でいいかも。
-                using var ms2 = new MemoryStream();
-                await imageFileStream.CopyToAsync(ms2);
 
-                req.HttpContext.Response.Headers.Add("Cache-Control", "public, max-age=31536000");
-                return new FileContentResult(ms2.ToArray(), convertFormat == ConvertFormat.Svg ? "image/svg+xml" : "image/png");
+                var imageResponse = req.CreateResponse(HttpStatusCode.OK);
+                imageResponse.Headers.Add("Cache-Control", CacheControl);
+                imageResponse.Headers.Add("Content-Type", convertFormat == ConvertFormat.Svg ? "image/svg+xml" : "image/png");
+                await imageFileStream.CopyToAsync(imageResponse.Body);
+                return imageResponse;
             }
 
-            req.HttpContext.Response.Headers.Add("Cache-Control", "public, max-age=31536000");
-            return new FileStreamResult(ms, "application/octet-stream")
+            using (ms)
             {
-                FileDownloadName = $"{name}.pptx"
-            };
+                var response = req.CreateResponse(HttpStatusCode.OK);
+                response.Headers.Add("Cache-Control", CacheControl);
+                response.Headers.Add("Content-Type", "application/octet-stream");
+                response.Headers.Add("Content-Disposition", ContentDisposition($"{name}.pptx"));
+                await ms.CopyToAsync(response.Body);
+                return response;
+            }
         }
 
-        [FunctionName(nameof(Viewer))]
+        [Function(nameof(Viewer))]
         [OpenApiOperation("Viewer", "Gurafu")]
         [OpenApiParameter(name: "name", In = ParameterLocation.Query, Required = true, Type = typeof(string), Description = "The **Name** parameter")]
         [OpenApiParameter(name: "from", In = ParameterLocation.Query, Required = true, Type = typeof(double), Description = "The **From** parameter")]
         [OpenApiParameter(name: "to", In = ParameterLocation.Query, Required = true, Type = typeof(double), Description = "The **To** parameter")]
         [OpenApiParameter(name: "nan", In = ParameterLocation.Query, Required = false, Type = typeof(Nan), Description = "The **Nan** parameter")]
         [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "text/html", bodyType: typeof(string))]
-        public async Task<IActionResult> Viewer(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "Viewer")] HttpRequest req
+        public async Task<HttpResponseData> Viewer(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "Viewer")] HttpRequestData req
         )
         {
-            _logger.LogInformation($"C# HTTP trigger function processed a request. path: {req.Path}, query: {req.QueryString}");
+            _logger.LogInformation("C# HTTP trigger function processed a request. path: {Path}, query: {Query}", req.Url.AbsolutePath, req.Url.Query);
 
-            string name = req.Query["name"];
-            var from = double.Parse(req.Query["from"]);
-            var to = double.Parse(req.Query["to"]);
-            var nan = (Nan)System.Enum.Parse(typeof(Nan), req.Query["nan"].FirstOrDefault() ?? "bai", true);
-            var bai = new Formatter().Format(from, to, nan);
+            var query = HttpUtility.ParseQueryString(req.Url.Query);
+            string name = query["name"];
+            var from = double.Parse(query["from"]);
+            var to = double.Parse(query["to"]);
+            var nan = (Nan)System.Enum.Parse(typeof(Nan), query["nan"] ?? "bai", true);
+            var bai = _formatter.Format(from, to, nan);
 
-            req.HttpContext.Response.Headers.Add("Cache-Control", "public, max-age=31536000");
+            // クエリ由来の値は HTML に直接埋め込まない (反射型 XSS 対策)
+            var encodedName = HtmlEscape(name);
+            var encodedBai = HtmlEscape(bai);
+            var encodedQueryString = HtmlEscape(req.Url.Query);
+
             // {req.Host} Funcion AppsのホストなのでCDNのホストどっかから取りたい
-            return new FileContentResult(Encoding.UTF8.GetBytes($"<html lang=\"ja\"><head>" +
+            return await Html(req, $"<html lang=\"ja\"><head>" +
                 $"<meta charset=\"UTF-8\">" +
-                $"<meta property=\"og:title\" content=\"{name}が{bai}!!!\">" +
-                $"<meta property=\"og:description\" content=\"{name}が{bai}!!!\">" +
-                $"<meta property=\"og:image\" content=\"https://n-bai.koudenpa.dev/api/Generate.png{req.QueryString}\">" +
-                $"<meta name=\"twitter:image\" content=\"https://n-bai.koudenpa.dev/api/Generate.png{req.QueryString}\">" +
+                $"<meta property=\"og:title\" content=\"{encodedName}が{encodedBai}!!!\">" +
+                $"<meta property=\"og:description\" content=\"{encodedName}が{encodedBai}!!!\">" +
+                $"<meta property=\"og:image\" content=\"https://n-bai.koudenpa.dev/api/Generate.png{encodedQueryString}\">" +
+                $"<meta name=\"twitter:image\" content=\"https://n-bai.koudenpa.dev/api/Generate.png{encodedQueryString}\">" +
                 $"<meta name=\"twitter:card\" content=\"summary_large_image\">" +
                 $"</head><body>" +
-                $"<div><img src=\"https://n-bai.koudenpa.dev/api/Generate.png{req.QueryString}\"></div>" +
+                $"<div><img src=\"https://n-bai.koudenpa.dev/api/Generate.png{encodedQueryString}\"></div>" +
                 $"<div><a href=\"https://github.com/7474/NantoNBai\">https://github.com/7474/NantoNBai</a></div>" +
-                $"</body></html>"), "text/html");
+                $"</body></html>");
         }
 
-        [FunctionName(nameof(Index))]
-        public async Task<IActionResult> Index(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "Index")] HttpRequest req
+        [Function(nameof(Index))]
+        public async Task<HttpResponseData> Index(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "Index")] HttpRequestData req
         )
         {
-            _logger.LogInformation($"C# HTTP trigger function processed a request. path: {req.Path}, query: {req.QueryString}");
+            _logger.LogInformation("C# HTTP trigger function processed a request. path: {Path}, query: {Query}", req.Url.AbsolutePath, req.Url.Query);
 
-            req.HttpContext.Response.Headers.Add("Cache-Control", "public, max-age=31536000");
-            return new FileContentResult(Encoding.UTF8.GetBytes($"<html lang=\"ja\"><head>" +
+            return await Html(req, $"<html lang=\"ja\"><head>" +
                 $"<meta charset=\"UTF-8\">" +
                 $"<meta property=\"og:title\" content=\"NantoNBai\">" +
                 $"<meta property=\"og:description\" content=\"なんと凄いグラフを作れます\">" +
@@ -134,8 +156,42 @@ namespace NantoNBaiFunction
                 $"<li><a href=\"https://n-bai.koudenpa.dev/api/swagger/ui\">https://n-bai.koudenpa.dev/api/swagger/ui</a></li>" +
                 $"<li><a href=\"https://github.com/7474/NantoNBai\">https://github.com/7474/NantoNBai</a></li>" +
                 $"</ul>" +
-                $"</body></html>"), "text/html"); 
+                $"</body></html>");
+        }
+
+        private static async Task<HttpResponseData> Html(HttpRequestData req, string html)
+        {
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            response.Headers.Add("Cache-Control", CacheControl);
+            response.Headers.Add("Content-Type", "text/html");
+            await response.WriteBytesAsync(Encoding.UTF8.GetBytes(html));
+            return response;
+        }
+
+        // HTML の特殊文字だけをエスケープする。
+        // WebUtility.HtmlEncode は非 ASCII も数値文字参照にしてしまい、
+        // 日本語を含む既存の出力バイト列が変わってしまうため使わない。
+        private static string HtmlEscape(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return string.Empty;
+            }
+
+            return value
+                .Replace("&", "&amp;")
+                .Replace("<", "&lt;")
+                .Replace(">", "&gt;")
+                .Replace("\"", "&quot;")
+                .Replace("'", "&#39;");
+        }
+
+        // ASP.NET Core の FileStreamResult 相当のヘッダを組み立てる。
+        // ファイル名は日本語になりうるので RFC 6266 の filename* を併記する。
+        private static string ContentDisposition(string fileName)
+        {
+            var ascii = new string(fileName.Select(c => c < 0x20 || c > 0x7e || c == '"' || c == '\\' ? '_' : c).ToArray());
+            return $"attachment; filename=\"{ascii}\"; filename*=UTF-8''{Uri.EscapeDataString(fileName)}";
         }
     }
 }
-

--- a/NantoNBaiFunction/NantoNBaiFunction.csproj
+++ b/NantoNBaiFunction/NantoNBaiFunction.csproj
@@ -2,11 +2,15 @@
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <!-- 分離ワーカーはワーカープロセスとして自身が起動するため実行可能ファイルにする -->
+    <OutputType>Exe</OutputType>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.OpenApi" Version="1.5.1" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.OpenApi" Version="1.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>

--- a/NantoNBaiFunction/Program.cs
+++ b/NantoNBaiFunction/Program.cs
@@ -1,0 +1,27 @@
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NantoNBai;
+
+// 分離ワーカーのエントリポイント。
+//
+// ASP.NET Core 統合 (ConfigureFunctionsWebApplication / HttpRequest / IActionResult) は
+// 意図的に採用していない。OpenAPI 拡張が提供する swagger エンドポイントは
+// 1.6.0 でも 2.0.0-preview2 でも HttpRequestData ベースのままで、
+// ASP.NET Core 統合と併用すると HttpRequestData の URL が上書きされ
+// swagger UI / swagger.json が壊れることが報告されているため。
+// https://github.com/Azure/azure-functions-dotnet-worker/issues/2071
+// https://github.com/Azure/azure-functions-openapi-extension/issues/617
+var host = new HostBuilder()
+    .ConfigureFunctionsWorkerDefaults(worker => worker.UseNewtonsoftJson())
+    .ConfigureOpenApi()
+    .ConfigureServices(services =>
+    {
+        services.AddSingleton<INantoNBaiService, NantoNBaiShapeCrawler>();
+        services.AddSingleton<Converter>();
+        services.AddSingleton<Formatter>();
+    })
+    .Build();
+
+await host.RunAsync();

--- a/NantoNBaiFunction/local.settings.sample.json
+++ b/NantoNBaiFunction/local.settings.sample.json
@@ -1,0 +1,7 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ sequenceDiagram
     Function->>CDN: "GURAFU" Image
     CDN->>UA: "GURAFU" Image
     Note over CDN: Azure CDN
-    Note over Function: Azure Functions<br/>.NET8 on Windows
+    Note over Function: Azure Functions<br/>.NET8 分離ワーカー on Windows
 ```
 
 このようなグラフの良いところの一つには、オフィスソフトで「雑に」作られたグラフであるところがあります。
@@ -64,3 +64,48 @@ FaaS...[Azure Functions](https://learn.microsoft.com/ja-jp/azure/azure-functions
 OpenXML はデータフォーマットなだけで、これによってpptxファイルを生成できても、画像データにはなりません。
 
 ありがとう [Spire.Presentation（無料版）](https://jp.e-iceblue.com/download/free-spire-presentation-for-net.html)。
+
+
+## Development
+
+Azure Functions の関数アプリは .NET 8 の**分離ワーカーモデル**で動いています。
+[in-process モデルは 2026-11-10 にサポートが終了する](https://azure.github.io/jpazpaas/2024/04/01/azure-functions-inprocess-end-of-support-FVN7-7PZ.html)ためです。
+
+オフィスドキュメントの操作と画像変換が Windows に依存しているため、
+ターゲットフレームワークは `net8.0-windows`、デプロイは x64 のままです。
+
+OpenAPI 拡張が提供する swagger エンドポイントは `HttpRequestData` ベースのままで
+ASP.NET Core 統合 (`ConfigureFunctionsWebApplication`) と併用すると壊れるため、
+関数は `HttpRequestData` / `HttpResponseData` で書いています。
+
+- https://github.com/Azure/azure-functions-dotnet-worker/issues/2071
+- https://github.com/Azure/azure-functions-openapi-extension/issues/617
+
+### ローカル実行
+
+`local.settings.json` はリポジトリに含めていないので、サンプルからコピーしてください。
+`FUNCTIONS_WORKER_RUNTIME` が `dotnet-isolated` でないとホストが起動しません。
+
+```sh
+cp NantoNBaiFunction/local.settings.sample.json NantoNBaiFunction/local.settings.json
+cd NantoNBaiFunction
+func start
+```
+
+### 疎通確認
+
+CI と CD が使っているものと同じスクリプトで、全エンドポイントの疎通を確認できます。
+
+```sh
+pwsh -File scripts/Invoke-SmokeTest.ps1 -BaseUrl http://localhost:7071
+```
+
+### デプロイ
+
+master への push で [CD](.github/workflows/cd.yml) が発行とデプロイを行い、
+デプロイ後に上記の疎通確認を実行します。
+
+in-process から分離ワーカーへの切り替えのように、
+ランタイム設定とペイロードを同時に入れ替える必要がある変更は、
+[Migrate to isolated worker](.github/workflows/migrate-to-isolated.yml) を手動実行してください。
+デプロイスロットで疎通確認してから本番とスワップするため、不整合な状態を本番に晒しません。

--- a/scripts/Invoke-SmokeTest.ps1
+++ b/scripts/Invoke-SmokeTest.ps1
@@ -1,0 +1,183 @@
+<#
+.SYNOPSIS
+    NantoNBai Function App のエンドポイント疎通を検証する。
+
+.DESCRIPTION
+    CI ではローカルで起動した Functions ホストに対して、CD ではデプロイ先に対して
+    同じ検証を実行する。分離ワーカー移行で壊れやすい以下を対象にしている。
+
+      - pptx テンプレートの解決 (AppContext.BaseDirectory)
+      - ワーカープロセス内での Spire.Presentation による画像変換
+      - OpenAPI 拡張が提供する swagger エンドポイント
+      - ルートプレフィックス (api) と Content-Type
+
+.PARAMETER BaseUrl
+    検証対象のベース URL。例: http://localhost:7071
+
+.PARAMETER ReadyTimeoutSeconds
+    最初の応答が返るまで待つ秒数。
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $BaseUrl,
+
+    [int] $ReadyTimeoutSeconds = 180
+)
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+$root = $BaseUrl.TrimEnd('/')
+# name=ポート番号&from=80&to=443 (README と E2E が使っているサンプル)
+$sampleQuery = 'name=%E3%83%9D%E3%83%BC%E3%83%88%E7%95%AA%E5%8F%B7&from=80&to=443'
+$failures = [System.Collections.Generic.List[string]]::new()
+
+function Get-Bytes {
+    param($Response)
+    return $Response.RawContentStream.ToArray()
+}
+
+function Get-Text {
+    param($Response)
+    return [System.Text.Encoding]::UTF8.GetString((Get-Bytes $Response))
+}
+
+function Get-ContentType {
+    param($Response)
+    foreach ($key in $Response.Headers.Keys) {
+        if ($key -ieq 'Content-Type') {
+            return (@($Response.Headers[$key]) -join '; ')
+        }
+    }
+    return ''
+}
+
+function Test-Endpoint {
+    param(
+        [string] $Name,
+        [string] $Path,
+        [string] $ExpectedContentType,
+        [scriptblock] $Assert
+    )
+
+    Write-Host "==> $Name : GET $Path"
+    try {
+        $response = Invoke-WebRequest -Uri "$root$Path" -UseBasicParsing -TimeoutSec 120
+        if ($response.StatusCode -ne 200) {
+            throw "期待 200 に対して $($response.StatusCode)"
+        }
+
+        $contentType = Get-ContentType $response
+        if ($ExpectedContentType -and $contentType -notlike "*$ExpectedContentType*") {
+            throw "Content-Type が '$ExpectedContentType' を含まない: '$contentType'"
+        }
+
+        if ($Assert) {
+            & $Assert $response
+        }
+
+        Write-Host "    OK  content-type=$contentType, $((Get-Bytes $response).Length) bytes"
+    }
+    catch {
+        $message = $_.Exception.Message
+        Write-Host "    NG  $message"
+        $failures.Add("${Name}: $message")
+    }
+}
+
+function Assert-Contains {
+    param([string] $Haystack, [string] $Needle, [string] $What)
+    if ($Haystack -notlike "*$Needle*") {
+        throw "$What に '$Needle' が含まれていない"
+    }
+}
+
+Write-Host "Smoke test target: $root"
+
+# --- ホストが応答するまで待つ ---------------------------------------------
+$deadline = (Get-Date).AddSeconds($ReadyTimeoutSeconds)
+$ready = $false
+while (-not $ready -and (Get-Date) -lt $deadline) {
+    try {
+        $probe = Invoke-WebRequest -Uri "$root/api/Index" -UseBasicParsing -TimeoutSec 15
+        if ($probe.StatusCode -eq 200) { $ready = $true; break }
+    }
+    catch {
+        Start-Sleep -Seconds 3
+    }
+}
+if (-not $ready) {
+    Write-Error "$ReadyTimeoutSeconds 秒以内に $root/api/Index が応答しなかった"
+    exit 1
+}
+Write-Host "Host is ready."
+Write-Host ''
+
+# --- HTML エンドポイント ---------------------------------------------------
+Test-Endpoint -Name 'Index' -Path '/api/Index' -ExpectedContentType 'text/html' -Assert {
+    param($response)
+    $text = Get-Text $response
+    Assert-Contains $text '<h1>NantoNBai</h1>' 'Index'
+    Assert-Contains $text '/api/swagger/ui' 'Index'
+}
+
+Test-Endpoint -Name 'Viewer' -Path "/api/Viewer?$sampleQuery" -ExpectedContentType 'text/html' -Assert {
+    param($response)
+    $text = Get-Text $response
+    # 日本語リテラルはスクリプトのエンコーディング差異で誤検知しうるので ASCII だけで検証する
+    Assert-Contains $text 'og:title' 'Viewer'
+    Assert-Contains $text 'twitter:card' 'Viewer'
+    Assert-Contains $text '/api/Generate.png' 'Viewer'
+}
+
+# --- グラフ生成 (Windows 依存のオフィスドキュメント処理) --------------------
+Test-Endpoint -Name 'Generate.pptx' -Path "/api/Generate.pptx?$sampleQuery" -ExpectedContentType 'application/octet-stream' -Assert {
+    param($response)
+    $bytes = Get-Bytes $response
+    if ($bytes.Length -lt 1024) { throw "pptx が小さすぎる: $($bytes.Length) bytes" }
+    # OOXML は zip なので 'PK'
+    if ($bytes[0] -ne 0x50 -or $bytes[1] -ne 0x4B) { throw 'pptx が zip (PK) で始まっていない' }
+}
+
+Test-Endpoint -Name 'Generate.png' -Path "/api/Generate.png?$sampleQuery" -ExpectedContentType 'image/png' -Assert {
+    param($response)
+    $bytes = Get-Bytes $response
+    if ($bytes.Length -lt 4096) { throw "png が小さすぎる: $($bytes.Length) bytes" }
+    $magic = @(0x89, 0x50, 0x4E, 0x47)
+    for ($i = 0; $i -lt $magic.Length; $i++) {
+        if ($bytes[$i] -ne $magic[$i]) { throw 'PNG シグネチャが不正' }
+    }
+}
+
+Test-Endpoint -Name 'Generate.svg' -Path "/api/Generate.svg?$sampleQuery" -ExpectedContentType 'image/svg+xml' -Assert {
+    param($response)
+    Assert-Contains (Get-Text $response) '<svg' 'svg'
+}
+
+# --- OpenAPI (ASP.NET Core 統合と非互換なため最重要) ------------------------
+Test-Endpoint -Name 'swagger.json' -Path '/api/swagger.json' -ExpectedContentType 'application/json' -Assert {
+    param($response)
+    $document = (Get-Text $response) | ConvertFrom-Json
+    if ($null -eq $document.paths) { throw 'swagger.json に paths がない' }
+    $paths = @($document.paths.PSObject.Properties.Name)
+    foreach ($expected in @('/Generate.{format}', '/Viewer')) {
+        if ($paths -notcontains $expected) {
+            throw "swagger.json に $expected がない (paths: $($paths -join ', '))"
+        }
+    }
+}
+
+Test-Endpoint -Name 'swagger/ui' -Path '/api/swagger/ui' -ExpectedContentType 'text/html' -Assert {
+    param($response)
+    Assert-Contains (Get-Text $response) 'swagger' 'swagger UI'
+}
+
+Write-Host ''
+if ($failures.Count -gt 0) {
+    Write-Host "FAILED ($($failures.Count))"
+    foreach ($failure in $failures) { Write-Host "  - $failure" }
+    exit 1
+}
+
+Write-Host 'All smoke tests passed.'


### PR DESCRIPTION
[#161](https://github.com/7474/NantoNBai/pull/161) のレビューで挙げた指摘を踏まえた、分離ワーカー移行の代替案です。#161 とは排他で、どちらかをマージする想定です。

Refs #90, #161

## なぜ別 PR にしたか

#161 の方針（ASP.NET Core 統合の採用、CD 内でのアプリケーション設定書き換え）は、部分的な修正では直せない設計上の選択でした。加えて #161 には移行が動作することの検証が 1 つもなく、CI も一度も実行されていませんでした。この PR は **「動くことを機械的に検証できる状態」までを含めて** 移行を行います。

## 方針の違い

| 論点 | #161 | この PR |
|---|---|---|
| HTTP バインディング | ASP.NET Core 統合 (`HttpRequest` / `IActionResult`) | `HttpRequestData` / `HttpResponseData` |
| OpenAPI | 動作未検証 | 公式にサポートされる組み合わせを採用し CI で検証済み |
| DI | `new` のまま | `Program.cs` で登録 |
| ランタイム設定の切り替え | CD が毎回 `az` で本番に適用 | スロット + スワップの手動ワークフロー |
| 検証 | なし | CI でホストを起動して全エンドポイントを検証 |

## OpenAPI と ASP.NET Core 統合は併用できない

`Microsoft.Azure.Functions.Worker.Extensions.OpenApi` の nupkg を展開して公開 API を確認したところ、swagger を提供する組み込み関数は **1.6.0 でも 2.0.0-preview2 でも全て `HttpRequestData` ベース** でした。

```
DefaultOpenApiHttpTrigger.RenderSwaggerUI(Microsoft.Azure.Functions.Worker.Http.HttpRequestData, FunctionContext)
DefaultOpenApiHttpTrigger.RenderOpenApiDocument(HttpRequestData, string, string, FunctionContext)
```

ASP.NET Core 統合は `HttpRequestData` の URL を上書きするため、この 2 つを併用すると `/api/swagger/ui` と `/api/swagger.json` が壊れることが報告されています。

- [Azure/azure-functions-dotnet-worker#2071](https://github.com/Azure/azure-functions-dotnet-worker/issues/2071)
- [Azure/azure-functions-openapi-extension#617](https://github.com/Azure/azure-functions-openapi-extension/issues/617)

swagger は README と `Index` 関数の両方から公開リンクとして案内している本番機能なので、ASP.NET Core 統合を諦めて `HttpRequestData` / `HttpResponseData` で書き直しました。`Program.cs` にこの経緯をコメントとして残しています。

## 変更内容

### 分離ワーカーへの移行

- `Microsoft.NET.Sdk.Functions` を分離ワーカーのパッケージ群に差し替え、`Program.cs` を追加
- `FunctionName` → `Function`
- `ExecutionContext.FunctionAppDirectory` → `AppContext.BaseDirectory`
- `INantoNBaiService` / `Converter` / `Formatter` を DI に登録し、関数側の `new` を廃止
- 関数を `HttpRequestData` / `HttpResponseData` に書き直し
- 書き直しに伴い、クエリ由来の値を素で HTML へ埋め込んでいた `Viewer` の反射型 XSS を修正

`net8.0-windows` と x64 は維持しています。

### CI / CD での検証

`scripts/Invoke-SmokeTest.ps1` を追加しました。ベース URL を渡すと Index / Viewer / Generate.{pptx,png,svg} / swagger.json / swagger/ui を検証します。これを 3 か所で使い回します。

1. **CI**: `func start` で分離ワーカーとして実際に起動して実行（新規 `smoke` ジョブ）
2. **CD**: デプロイ直後に本番に対して実行。E2E は CD 完了後の別ワークフローなので、壊れたデプロイをより早く赤くする
3. **移行ワークフロー**: スロットとスワップ後の本番に対して実行

Core Tools は windows-latest に入っておらず npm 経由の導入もレジストリ認証に失敗したため、公式のリリースフィード (`cli-feed-v4.json`) から取得し、フィードが公開している SHA256 と照合してから展開しています。

あわせて CI/CD の双方で、発行成果物に `host.json` / `worker.config.json` / `functions.metadata` / テンプレート pptx が含まれることを確認します。E2E にも `swagger.json` の検証を追加しました。

**発行先の分離**: `WORKING_DIRECTORY` と `AZURE_FUNCTIONAPP_PACKAGE_PATH` が同一だったため、`dotnet publish` がソースディレクトリに発行し、`*.cs` や `obj/` ごとデプロイパッケージに含まれていました。発行先を `functionapp/` に分けています。

### スロットベースの移行ワークフロー

`FUNCTIONS_WORKER_RUNTIME` とペイロードは同時に入れ替わる必要があります。本番へ直接適用すると、設定変更による再起動からデプロイ完了までランタイムとペイロードが不整合になり、デプロイに失敗すると起動不能のまま戻せません。

[JPAZPAAS のスロットを使った移行手順](https://azure.github.io/jpazpaas/2024/08/30/migrate-azure-functions-inprocess-to-isolated-using-slot.html)に沿って、`workflow_dispatch` の一度きりのワークフローに切り出しました。

1. スロットを用意する（無ければ作成）
2. スロットに `FUNCTIONS_WORKER_RUNTIME=dotnet-isolated` を設定し、`FUNCTIONS_INPROC_NET8_ENABLED` を削除する
3. スロットへデプロイする
4. スロットに対して疎通確認する
5. `swap` 入力が true のときだけ本番とスワップし、本番に対して再度疎通確認する

スワップ対象外に指定していないアプリケーション設定はスロットと一緒に移動するため、ランタイム設定とペイロードが同時に本番へ入れ替わります。

リソースグループは実行時入力で、サブスクリプション全体の列挙権限を要求しません。`az` の各コマンドの終了コードも検査しています。定常運用の CD からはこの処理を取り除いたので、master への push のたびにアプリが再起動することもありません。

## 検証結果

### CI（windows-latest、実機）

[run #271](https://github.com/7474/NantoNBai/actions/runs/32820282869) が緑です。`smoke` ジョブで分離ワーカーとして Functions ホストを起動し、全エンドポイントが通っています。

```
==> Index : GET /api/Index
    OK  content-type=text/html, 949 bytes
==> Viewer : GET /api/Viewer?name=...&from=80&to=443
    OK  content-type=text/html, 798 bytes
==> Generate.pptx : GET /api/Generate.pptx?...
    OK  content-type=application/octet-stream, 45844 bytes
==> Generate.png : GET /api/Generate.png?...
    OK  content-type=image/png, 17864 bytes
==> Generate.svg : GET /api/Generate.svg?...
    OK  content-type=image/svg+xml, 6475 bytes
==> swagger.json : GET /api/swagger.json
    OK  content-type=application/json, 3475 bytes
==> swagger/ui : GET /api/swagger/ui
    OK  content-type=text/html, 1914189 bytes

All smoke tests passed.
```

Functions ホスト側のログでも、7 つの関数が登録され全て成功しています。

```
	Generate: [GET] http://localhost:7071/api/Generate.{format}
	Index: [GET] http://localhost:7071/api/Index
	RenderOAuth2Redirect: [GET] http://localhost:7071/api/oauth2-redirect.html
	RenderOpenApiDocument: [GET] http://localhost:7071/api/openapi/{version}.{extension}
	RenderSwaggerDocument: [GET] http://localhost:7071/api/swagger.{extension}
	RenderSwaggerUI: [GET] http://localhost:7071/api/swagger/ui
	Viewer: [GET] http://localhost:7071/api/Viewer

Executed 'Functions.Generate' (Succeeded, ..., Duration=4550ms)   # Generate.png
Executed 'Functions.RenderSwaggerDocument' (Succeeded, ..., Duration=1809ms)
Executed 'Functions.RenderSwaggerUI' (Succeeded, ..., Duration=81ms)
```

**これで Issue #90 が挙げていた「オフィスドキュメントの操作など分離ワーカーでは動作しない処理がある」という懸念に答えが出ました。** ShapeCrawler による pptx 生成も Spire.Presentation による png / svg 変換も、`net8.0-windows` / x64 を維持したまま分離ワーカーのワーカープロセス内で動作します。これは CI に残るので、以後の変更でも検証され続けます。

### この環境で追加で確認したこと

**発行成果物** — テンプレート pptx がワーカーアセンブリと同じディレクトリに置かれるので `AppContext.BaseDirectory` での解決が成立します。`local.settings.json` は発行されません。

```
OK   host.json
OK   worker.config.json
OK   functions.metadata
OK   NantoNBaiFunction.dll
OK   nanto-n-bai-template.pptx
OK   nanto-n-bai-template(1).pptx
--- local.settings.json should be absent:
absent (good)
```

**パッケージのバージョン整合** — `Extensions.OpenApi` 1.6.0 は `Worker.Core` 1.8.0 に依存しており `Worker` 2.52.0 とはメジャーバージョンを跨ぎますが、CI の実機起動で swagger エンドポイントまで通ったので問題ありません。

**Linux での参考実行** — Core Tools の Linux 版でも起動を確認しました。`swagger.json` / `swagger/ui` / `Generate.pptx` は成功し、`Generate.png` / `Generate.svg` のみ `System.Drawing.Common is not supported on non-Windows platforms` で 500 になりました。Windows 依存が画像変換に閉じていることの裏付けにもなっています。

**スモークテストスクリプト自体** — モックサーバに対して正常系（exit 0）と異常系（`Content-Type` 不一致と `swagger.json` の `paths` 欠落を検出し exit 1）の両方を確認済みです。

## マージ手順

1. この PR をマージする
2. CD が走るが、この時点では本番はまだ in-process ランタイムなので **デプロイ後の疎通確認は失敗する**（想定内）
3. Actions から **Migrate to isolated worker** を `swap: false` で実行し、スロットの疎通確認が通ることを確認する
4. 同ワークフローを `swap: true` で実行して本番へ反映する

3 と 4 にはリソースグループ名の入力が必要です。

CI は緑ですが、上記の Azure 側手順の判断が必要なので draft のままにしています。方針に問題がなければ ready にしてください。

## この PR に含めなかったもの

- **入力値の検証**: `double.Parse` / `Enum.Parse` は不正なクエリで 500 を返します。400 を返すべきですが、観測可能な挙動が変わるため移行とは分けるべきと判断しました
- **ワーカー側の Application Insights 登録**: 分離ワーカーでもワーカーのログはホスト経由で Application Insights に届くため、移行の必須要件ではないと判断しました
- **`Viewer` / `Index` の `async` 化解消**: `HttpResponseData` の書き込みが非同期になったため、この PR では実際に `await` するようになり自然に解消しています