### PR TITLE
Add a production target to the isolated worker migration workflow

### DIFF
--- a/.github/workflows/migrate-to-isolated.yml
+++ b/.github/workflows/migrate-to-isolated.yml
@@ -1,13 +1,22 @@
 # in-process モデルから分離ワーカーへの切り替えを行う一度きりのワークフロー。
 #
 # FUNCTIONS_WORKER_RUNTIME (ランタイム) とデプロイパッケージ (ペイロード) は
-# 同時に入れ替わらなければならない。本番に直接適用すると、
-# 設定変更→再起動→デプロイ完了までの間ランタイムとペイロードが不整合になり、
-# デプロイに失敗した場合は起動不能のまま戻せなくなる。
+# 同時に入れ替わらなければならない。片方だけを適用するとホストが関数を
+# 一つもロードできず、全エンドポイントが 404 になる。
 #
-# そのためデプロイスロットに新構成を載せ、疎通確認に成功してからスワップする。
-# スワップ対象外に指定していないアプリケーション設定はスロットと一緒に移動するので、
-# ランタイム設定とペイロードが同時に本番へ入れ替わる。
+# target で 2 つの適用方法を選ぶ。
+#
+#   slot        デプロイスロットに新構成を載せ、疎通確認に成功してから
+#               スワップする。無停止だが、スロットの作成・スワップには
+#               Function App だけでなく App Service プランへの権限が要る。
+#               (Microsoft.Web/serverFarms/read, serverFarms/join/action)
+#               組み込みロールなら Website Contributor が該当する。
+#
+#   production  本番へ直接適用する。ダウンタイムを伴い、失敗しても自動では
+#               戻らない。必要な権限は Microsoft.Web/sites/config/write だけで、
+#               通常のデプロイと同じ範囲で済む。
+#               スロットが使えない場合と、ランタイムとペイロードが既に
+#               食い違っていて復旧が必要な場合に使う。
 #
 # 参考: https://azure.github.io/jpazpaas/2024/08/30/migrate-azure-functions-inprocess-to-isolated-using-slot.html
 name: Migrate to isolated worker
@@ -15,17 +24,30 @@ name: Migrate to isolated worker
 on:
   workflow_dispatch:
     inputs:
+      target:
+        description: '適用先'
+        required: true
+        default: slot
+        type: choice
+        options:
+          - slot
+          - production
       resource_group:
         description: 'Function App のリソースグループ名'
         required: true
         type: string
       slot:
-        description: '検証に使うデプロイスロット名'
+        description: '[slot] 検証に使うデプロイスロット名'
         required: true
         default: staging
         type: string
+      create_slot:
+        description: '[slot] スロットが無ければ作成する (App Service プランへの権限が必要)'
+        required: true
+        default: false
+        type: boolean
       swap:
-        description: '疎通確認に成功したらスロットを本番とスワップする'
+        description: '[slot] 疎通確認に成功したらスロットを本番とスワップする'
         required: true
         default: false
         type: boolean
@@ -58,55 +80,48 @@ jobs:
         tenant-id: ${{ secrets.__tenantidsecretname__ }}
         subscription-id: ${{ secrets.__subscriptionidsecretname__ }}
 
-    - name: Ensure deployment slot
+    # --- slot ---------------------------------------------------------------
+    - name: Create deployment slot
+      if: ${{ inputs.target == 'slot' && inputs.create_slot }}
       shell: pwsh
       env:
         APP_NAME: ${{ env.AZURE_FUNCTIONAPP_NAME }}
         RESOURCE_GROUP: ${{ inputs.resource_group }}
         SLOT: ${{ inputs.slot }}
       run: |
-        $ErrorActionPreference = 'Stop'
-        $slots = az functionapp deployment slot list --name $env:APP_NAME --resource-group $env:RESOURCE_GROUP --query '[].name' --output tsv
-        if ($LASTEXITCODE -ne 0) { throw 'デプロイスロットの一覧取得に失敗した' }
-        $existing = @($slots -split "`n" | ForEach-Object { $_.Trim() } | Where-Object { $_ })
-        if ($existing -contains $env:SLOT) {
-          Write-Host "スロット '$($env:SLOT)' は既に存在する"
-        } else {
-          Write-Host "スロット '$($env:SLOT)' を作成する"
-          az functionapp deployment slot create --name $env:APP_NAME --resource-group $env:RESOURCE_GROUP --slot $env:SLOT
-          if ($LASTEXITCODE -ne 0) { throw 'デプロイスロットの作成に失敗した' }
+        $ErrorActionPreference = 'Continue'
+        # 既に存在する場合の Conflict は成功として扱う
+        $output = az functionapp deployment slot create `
+          --name $env:APP_NAME --resource-group $env:RESOURCE_GROUP --slot $env:SLOT 2>&1 | Out-String
+        if ($LASTEXITCODE -ne 0) {
+          Write-Host $output
+          if ($output -match 'Conflict' -or $output -match 'already exists') {
+            Write-Host "スロット '$($env:SLOT)' は既に存在するとみなして続行する"
+          } elseif ($output -match 'AuthorizationFailed') {
+            throw @"
+        スロットの作成に必要な権限がありません。
+        サービスプリンシパルに App Service プランへの権限
+        (Microsoft.Web/serverFarms/read, Microsoft.Web/serverFarms/join/action) が必要です。
+        組み込みロールなら Website Contributor をリソースグループに割り当ててください。
+        権限を広げたくない場合は、スロットを手動で作成してから create_slot=false で再実行するか、
+        target=production を使ってください。
+        "@
+          } else {
+            throw 'デプロイスロットの作成に失敗した'
+          }
         }
 
     - name: Configure slot for the isolated worker
+      if: ${{ inputs.target == 'slot' }}
       shell: pwsh
       env:
         APP_NAME: ${{ env.AZURE_FUNCTIONAPP_NAME }}
         RESOURCE_GROUP: ${{ inputs.resource_group }}
         SLOT: ${{ inputs.slot }}
-      run: |
-        $ErrorActionPreference = 'Stop'
-        az functionapp config appsettings set `
-          --name $env:APP_NAME --resource-group $env:RESOURCE_GROUP --slot $env:SLOT `
-          --settings FUNCTIONS_WORKER_RUNTIME=dotnet-isolated --output none
-        if ($LASTEXITCODE -ne 0) { throw 'FUNCTIONS_WORKER_RUNTIME の設定に失敗した' }
-
-        # .NET 8 の in-process モデルを有効化する設定。分離ワーカーでは不要で、
-        # 残したままにすると挙動が未定義になるため削除する。
-        $names = az functionapp config appsettings list `
-          --name $env:APP_NAME --resource-group $env:RESOURCE_GROUP --slot $env:SLOT `
-          --query '[].name' --output tsv
-        if ($LASTEXITCODE -ne 0) { throw 'アプリケーション設定の一覧取得に失敗した' }
-        if (@($names -split "`n" | ForEach-Object { $_.Trim() }) -contains 'FUNCTIONS_INPROC_NET8_ENABLED') {
-          az functionapp config appsettings delete `
-            --name $env:APP_NAME --resource-group $env:RESOURCE_GROUP --slot $env:SLOT `
-            --setting-names FUNCTIONS_INPROC_NET8_ENABLED --output none
-          if ($LASTEXITCODE -ne 0) { throw 'FUNCTIONS_INPROC_NET8_ENABLED の削除に失敗した' }
-          Write-Host 'FUNCTIONS_INPROC_NET8_ENABLED を削除した'
-        } else {
-          Write-Host 'FUNCTIONS_INPROC_NET8_ENABLED は設定されていない'
-        }
+      run: ./scripts/Set-IsolatedWorkerSettings.ps1 -AppName $env:APP_NAME -ResourceGroup $env:RESOURCE_GROUP -Slot $env:SLOT
 
     - name: Deploy to slot
+      if: ${{ inputs.target == 'slot' }}
       uses: Azure/functions-action@0bd707f87c0b6385742bab336c74e1afc61f6369 # v1
       with:
         app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
@@ -114,6 +129,7 @@ jobs:
         package: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
 
     - name: Smoke test slot
+      if: ${{ inputs.target == 'slot' }}
       shell: pwsh
       env:
         APP_NAME: ${{ env.AZURE_FUNCTIONAPP_NAME }}
@@ -129,7 +145,7 @@ jobs:
         pwsh -File ./scripts/Invoke-SmokeTest.ps1 -BaseUrl "https://$($slotHost.Trim())"
 
     - name: Swap slot into production
-      if: ${{ inputs.swap }}
+      if: ${{ inputs.target == 'slot' && inputs.swap }}
       shell: pwsh
       env:
         APP_NAME: ${{ env.AZURE_FUNCTIONAPP_NAME }}
@@ -142,8 +158,28 @@ jobs:
           --slot $env:SLOT --target-slot production --output none
         if ($LASTEXITCODE -ne 0) { throw 'スロットのスワップに失敗した' }
 
+    # --- production ---------------------------------------------------------
+    # 設定を先に入れ替えてからデプロイする。
+    # 分離ワーカーのペイロードが既に載っている状態 (ランタイム設定だけが
+    # 古い状態) からの復旧では、設定の反映だけで即座に復旧する。
+    - name: Configure production for the isolated worker
+      if: ${{ inputs.target == 'production' }}
+      shell: pwsh
+      env:
+        APP_NAME: ${{ env.AZURE_FUNCTIONAPP_NAME }}
+        RESOURCE_GROUP: ${{ inputs.resource_group }}
+      run: ./scripts/Set-IsolatedWorkerSettings.ps1 -AppName $env:APP_NAME -ResourceGroup $env:RESOURCE_GROUP
+
+    - name: Deploy to production
+      if: ${{ inputs.target == 'production' }}
+      uses: Azure/functions-action@0bd707f87c0b6385742bab336c74e1afc61f6369 # v1
+      with:
+        app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
+        package: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
+
+    # --- 共通 ---------------------------------------------------------------
     - name: Smoke test production
-      if: ${{ inputs.swap }}
+      if: ${{ inputs.target == 'production' || (inputs.target == 'slot' && inputs.swap) }}
       shell: pwsh
       env:
         APP_NAME: ${{ env.AZURE_FUNCTIONAPP_NAME }}

--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ master への push で [CD](.github/workflows/cd.yml) が発行とデプロイ�
 デプロイ後に上記の疎通確認を実行します。
 
 in-process から分離ワーカーへの切り替えのように、
-ランタイム設定とペイロードを同時に入れ替える必要がある変更は、
+ランタイム設定 (`FUNCTIONS_WORKER_RUNTIME`) とペイロードを同時に入れ替える必要がある変更は、
 [Migrate to isolated worker](.github/workflows/migrate-to-isolated.yml) を手動実行してください。
-デプロイスロットで疎通確認してから本番とスワップするため、不整合な状態を本番に晒しません。
+片方だけを適用するとホストが関数を一つもロードできず、全エンドポイントが 404 になります。
+
+`target` で 2 つの適用方法を選べます。
+
+| target | 動作 | 必要な権限 |
+| --- | --- | --- |
+| `slot` | スロットに載せて疎通確認してからスワップする。無停止。 | Function App に加えて App Service プランへの権限 (`Microsoft.Web/serverFarms/read`, `serverFarms/join/action`)。組み込みロールなら **Website Contributor** |
+| `production` | 本番へ直接適用する。ダウンタイムを伴い、失敗しても自動では戻らない。 | `Microsoft.Web/sites/config/write` のみ。通常のデプロイと同じ範囲 |
+
+スロットを使う権限が無い場合や、ランタイム設定とペイロードが既に食い違っていて
+復旧が必要な場合は `production` を使ってください。

--- a/scripts/Set-IsolatedWorkerSettings.ps1
+++ b/scripts/Set-IsolatedWorkerSettings.ps1
@@ -1,0 +1,66 @@
+<#
+.SYNOPSIS
+    Function App (または そのデプロイスロット) を分離ワーカー向けの設定にする。
+
+.DESCRIPTION
+    - FUNCTIONS_WORKER_RUNTIME を dotnet-isolated にする
+    - .NET 8 の in-process モデルを有効化する FUNCTIONS_INPROC_NET8_ENABLED を削除する
+      (分離ワーカーでは不要で、残したままにすると挙動が未定義になる)
+
+    必要な権限は Microsoft.Web/sites/config/read と write だけで、
+    App Service プランへの権限は要らない。
+
+.PARAMETER AppName
+    Function App 名。
+
+.PARAMETER ResourceGroup
+    リソースグループ名。
+
+.PARAMETER Slot
+    デプロイスロット名。省略すると本番 (production) に適用する。
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $AppName,
+
+    [Parameter(Mandatory = $true)]
+    [string] $ResourceGroup,
+
+    [string] $Slot
+)
+
+$ErrorActionPreference = 'Stop'
+
+$slotArgs = @()
+$label = 'production'
+if ($Slot) {
+    $slotArgs = @('--slot', $Slot)
+    $label = "slot '$Slot'"
+}
+
+Write-Host "分離ワーカー向けの設定を $AppName の $label に適用する"
+
+az functionapp config appsettings set `
+    --name $AppName --resource-group $ResourceGroup $slotArgs `
+    --settings FUNCTIONS_WORKER_RUNTIME=dotnet-isolated --output none
+if ($LASTEXITCODE -ne 0) { throw 'FUNCTIONS_WORKER_RUNTIME の設定に失敗した' }
+Write-Host 'FUNCTIONS_WORKER_RUNTIME=dotnet-isolated を設定した'
+
+$names = az functionapp config appsettings list `
+    --name $AppName --resource-group $ResourceGroup $slotArgs `
+    --query '[].name' --output tsv
+if ($LASTEXITCODE -ne 0) { throw 'アプリケーション設定の一覧取得に失敗した' }
+
+$existing = @($names -split "`n" | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+if ($existing -contains 'FUNCTIONS_INPROC_NET8_ENABLED') {
+    az functionapp config appsettings delete `
+        --name $AppName --resource-group $ResourceGroup $slotArgs `
+        --setting-names FUNCTIONS_INPROC_NET8_ENABLED --output none
+    if ($LASTEXITCODE -ne 0) { throw 'FUNCTIONS_INPROC_NET8_ENABLED の削除に失敗した' }
+    Write-Host 'FUNCTIONS_INPROC_NET8_ENABLED を削除した'
+} else {
+    Write-Host 'FUNCTIONS_INPROC_NET8_ENABLED は設定されていない'
+}
+
+Write-Host '設定の適用が完了した。アプリは再起動する。'


### PR DESCRIPTION
## 現状: 本番が停止しています

[CD run #85](https://github.com/7474/NantoNBai/actions/runs/32876419074) で分離ワーカーのペイロードが本番へデプロイされましたが、本番の `FUNCTIONS_WORKER_RUNTIME` は `dotnet` (in-process) のままです。ホストが関数を一つもロードできず、全エンドポイントが 404 を返しています。

```
/api/Index                                   404
/api/Generate.png?name=...&from=80&to=443    404
/api/swagger.json                            404
```

デプロイ自体は成功し、その直後の疎通確認が失敗して CD が赤くなっています（ステップ `Deploy to Azure Function App` = success、`Smoke test deployed app` = failure）。#162 の本文に書いた「マージ直後は疎通確認が失敗する（想定内）」の状態そのものですが、**その後の復旧手段であるスロット経路が権限不足で使えなかった** ため、復旧できないまま止まっています。

## スロット経路が失敗した理由

[migrate run](https://github.com/7474/NantoNBai/actions/runs/32877142218/job/97897723053) は最初の `az functionapp deployment slot list` で落ちました。

```
ERROR: (AuthorizationFailed) The client ... does not have authorization to perform action
'Microsoft.Web/serverfarms/read' over scope
'/subscriptions/***/resourceGroups/nanto-n-bai-w/providers/Microsoft.Web/serverfarms/ASP-NantoNBaiFunctionW-84b9'
```

サービスプリンシパルは Function App (`Microsoft.Web/sites/*`) には権限がありますが、App Service プラン (`Microsoft.Web/serverFarms`) には権限がありません。スロットの作成・スワップは本質的にプランへの権限を要求するため、これは私の設計ミスです。#161 のレビューで「サブスクリプション全体の列挙権限を要求している」と指摘しておきながら、自分の案でも既存の権限で足りるかを確認していませんでした。

## この PR の変更

### `target` 入力を追加

| target | 動作 | 必要な権限 |
| --- | --- | --- |
| `slot` | スロットに載せて疎通確認してからスワップ。無停止。 | Function App に加え App Service プランへの権限 (`Microsoft.Web/serverFarms/read`, `serverFarms/join/action`)。組み込みロールなら [Website Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/web-and-mobile) |
| `production` | 本番へ直接適用。ダウンタイムを伴い、失敗しても自動では戻らない。 | `Microsoft.Web/sites/config/write` のみ。通常のデプロイと同じ範囲 |

`production` は設定の適用 → デプロイ → 疎通確認の順に実行します。**今回のように分離ワーカーのペイロードが既に載っていてランタイム設定だけが古い状態では、設定の適用だけで即座に復旧します。**

### そのほか

- 設定の適用を `scripts/Set-IsolatedWorkerSettings.ps1` に切り出し、スロットと本番で共用する
- `serverFarms/read` を要求していた `slot list` による事前確認をやめる。スロットの作成は `create_slot` 入力で明示したときだけ行い、`AuthorizationFailed` のときは必要なロールを示して失敗する
- README に 2 つの経路と必要な権限を追記する

## 復旧手順

このワークフローは既に master にあるので、**この PR をマージしなくても、ブランチを指定して実行できます。**

Actions → Migrate to isolated worker → Run workflow →
- Use workflow from: `claude/pr-161-strict-review-yixxrz`
- target: `production`
- resource_group: `nanto-n-bai-w`

これより速いのは、手元の `az` で設定だけ入れ替えることです。ペイロードは既に本番に載っているので、これだけで復旧します。

```sh
az functionapp config appsettings set \
  --name NantoNBaiFunctionW --resource-group nanto-n-bai-w \
  --settings FUNCTIONS_WORKER_RUNTIME=dotnet-isolated

az functionapp config appsettings delete \
  --name NantoNBaiFunctionW --resource-group nanto-n-bai-w \
  --setting-names FUNCTIONS_INPROC_NET8_ENABLED
```

復旧後にスロット経路も使えるようにするなら、サービスプリンシパルにリソースグループ `nanto-n-bai-w` スコープで **Website Contributor** を割り当ててください。このロールは `Microsoft.Web/sites/*` と `Microsoft.Web/serverFarms/read`、`serverFarms/join/action` を含みます。サブスクリプション全体ではなくリソースグループに閉じます。

## 検証

`Set-IsolatedWorkerSettings.ps1` は `az` のスタブを使って、本番／スロット双方で組み立てられるコマンドラインと、失敗時に非ゼロで終了することを確認しています。

```
AZ-ARGS: functionapp config appsettings set --name APP --resource-group RG --settings FUNCTIONS_WORKER_RUNTIME=dotnet-isolated --output none
AZ-ARGS: functionapp config appsettings list --name APP --resource-group RG --query [].name --output tsv
AZ-ARGS: functionapp config appsettings delete --name APP --resource-group RG --setting-names FUNCTIONS_INPROC_NET8_ENABLED --output none

AZ-ARGS: functionapp config appsettings set --name APP --resource-group RG --slot staging --settings ...
```

Azure に対する実行は権限とリソースの都合でこの環境からは確認できません。`production` 経路の実行結果はワークフローの疎通確認が判定します。

---
_Generated by [Claude Code](https://claude.ai/code/session_015xYCNr12m8H3mYi4n848ac)_