### PR TITLE
全呼び出しが404になる原因 (.azurefunctions の欠落) を修正する

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,6 +49,10 @@ jobs:
       with:
         name: functionapp
         path: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
+        # 分離ワーカーのホスト側拡張は隠しディレクトリ .azurefunctions/ に発行される。
+        # 既定では隠しファイルが除外され、拡張を読み込めないホストが関数を 1 つも
+        # 登録しないまま起動する (全呼び出しが 404 になる)。
+        include-hidden-files: true
   deploy:
     runs-on: windows-latest
     needs: build
@@ -57,7 +61,7 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: Login to Azure
-      uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
+      uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
       with:
         client-id: ${{ secrets.__clientidsecretname__ }}
         tenant-id: ${{ secrets.__tenantidsecretname__ }}
@@ -68,7 +72,7 @@ jobs:
         name: functionapp
         path: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
     - name: Deploy to Azure Function App
-      uses: Azure/functions-action@0bd707f87c0b6385742bab336c74e1afc61f6369 # v1
+      uses: Azure/functions-action@c5060b3b8bb1ebbcb531abd00c822ecbaa8ea656 # v1.5.7
       with:
         app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
         package: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}

--- a/README.md
+++ b/README.md
@@ -104,10 +104,3 @@ pwsh -File scripts/Invoke-SmokeTest.ps1 -BaseUrl http://localhost:7071
 
 master への push で [CD](.github/workflows/cd.yml) が発行とデプロイを行い、
 デプロイ後に上記の疎通確認を実行します。
-
-分離ワーカーではホスト側の WebJobs 拡張が隠しディレクトリ `.azurefunctions` に発行されます。
-`actions/upload-artifact` は既定で隠しファイルを除外するため、
-[公式テンプレート](https://learn.microsoft.com/ja-jp/azure/azure-functions/functions-how-to-github-actions)
-同様に `include-hidden-files: true` が必要です。
-これが欠けるとホストは拡張を読み込めず、関数を 1 つも登録しないまま起動し、
-デプロイが成功しているのに `/api/*` の全呼び出しが 404 になります。

--- a/README.md
+++ b/README.md
@@ -104,3 +104,10 @@ pwsh -File scripts/Invoke-SmokeTest.ps1 -BaseUrl http://localhost:7071
 
 master への push で [CD](.github/workflows/cd.yml) が発行とデプロイを行い、
 デプロイ後に上記の疎通確認を実行します。
+
+分離ワーカーではホスト側の WebJobs 拡張が隠しディレクトリ `.azurefunctions` に発行されます。
+`actions/upload-artifact` は既定で隠しファイルを除外するため、
+[公式テンプレート](https://learn.microsoft.com/ja-jp/azure/azure-functions/functions-how-to-github-actions)
+同様に `include-hidden-files: true` が必要です。
+これが欠けるとホストは拡張を読み込めず、関数を 1 つも登録しないまま起動し、
+デプロイが成功しているのに `/api/*` の全呼び出しが 404 になります。


### PR DESCRIPTION
## 症状

`https://n-bai.koudenpa.dev/api/*` および `https://nantonbaifunctionw.azurewebsites.net/api/*` の**全呼び出しが 404**。
一方でサイトのルート `/` は 200 (`Your Azure Function App is up and running.`) を返す。
ホストは起動しているが、関数が 1 つも登録されていない状態。

CD は #162 (分離ワーカー移行) 以降 5 回連続で失敗しており、落ちているのはデプロイ後の疎通確認ステップ。
デプロイ自体 (`Successfully deployed web package to App Service.`) は成功している。

## 原因

デプロイパッケージから隠しディレクトリ `.azurefunctions/` が丸ごと欠落していた。

失敗した CD の成果物 (run 32885320408 の functionapp アーティファクト) を展開して確認した結果:

- ルート直下の 59 ファイルのみで、`.azurefunctions/` のエントリが 0 件
- ビルドログも `With the provided path, there will be 59 files uploaded`
- `extensions.json` は `./.azurefunctions/Microsoft.Azure.WebJobs.Extensions.FunctionMetadataLoader.dll` を参照している

分離ワーカーではホスト側の WebJobs 拡張 (HTTP トリガーの実装、関数メタデータローダー) が
隠しディレクトリ `.azurefunctions/` に発行される。これが無いとホストは `extensions.json` の
hintPath を解決できず、関数を登録できないまま起動する。ルートページだけは応答するため気付きにくい。

欠落は `actions/upload-artifact` の仕様変更が原因。v4 以降は隠しファイルを既定で除外する。

CI の疎通確認 (smoke job) が緑だったのは、発行と `func start` が同一ジョブで完結し
アーティファクトを経由しないため。この経路差がそのまま検出漏れになっていた。

## 変更

[公式テンプレート](https://learn.microsoft.com/ja-jp/azure/azure-functions/functions-how-to-github-actions)
と同じく `upload-artifact` に `include-hidden-files: true` を指定する (公式も .NET 向けに明示している)。
README に理由を追記。

### デプロイ経路の Action 更新

`Azure/functions-action` は**非推奨ではない** (最新 v1.5.7 / 2026-08-06、Microsoft Learn も
`azure/login` + `Azure/functions-action@v1` を現行の推奨として記載)。ただしピン留めが古かったので更新した。

| Action | 変更前 | 変更後 |
| --- | --- | --- |
| `Azure/functions-action` | `0bd707f` = v1.5.3 (2024-04) | `c5060b3` = v1.5.7 |
| `azure/login` | `a457da9` = v2.3.0 | `f5d393a` = v3.0.1 (Node 20 → 24) |

dependabot が SHA ピンのまま v1.5.3 に止まっていたのが陳腐化の原因。
`actions/checkout` / `setup-dotnet` / `upload-artifact` / `download-artifact` は
dependabot が追従しているためこの PR では触っていない。

## 検証

- 失敗した CD の実成果物をダウンロードして展開し、`.azurefunctions/` が 0 件であること、
  `extensions.json` の hintPath が解決不能であることを確認した
- 本番の現物確認: `/` は 200、`/api/Index` と `/api/swagger.json` は 404
- ワークフロー YAML の構文を検証済み

**マージ後、master への push で CD が走り、デプロイ後の疎通確認が実際の合否を示します。**
それでも 404 が続く場合、残る容疑はワーカープロセスの起動失敗 (サイトの `netFrameworkVersion` が
`net10.0-windows` より古い) です。
