### PR TITLE
レンダリング結果の退行を直す (評価透かしとタイトルのフォント)

### DIFF
--- a/NantoNBai/Converter.cs
+++ b/NantoNBai/Converter.cs
@@ -27,7 +27,7 @@ namespace NantoNBai
                 case ConvertFormat.Png:
                     {
                         using var image = slide.SaveAsImage();
-                        image.CopyTo(ms);
+                        image.Save(ms, ImageFormat.Png);
                     }
                     break;
                 default:

--- a/NantoNBai/NantoNBai.csproj
+++ b/NantoNBai/NantoNBai.csproj
@@ -1,14 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <!-- 画像変換が System.Drawing (Windows 専用) を使うため Windows 向けにする -->
+    <TargetFramework>net10.0-windows</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FreeSpire.Presentation" Version="11.4.0" />
+    <!-- 上げられない。
+         11.4.0 は Free 版の評価透かし (Evaluation Warning) を変換した画像に焼き込む。
+         9.3.0 は透かしを入れないが SkiaSharp 1.68 を要求し、
+         ShapeCrawler が要求する SkiaSharp 4.x と実行時に衝突する
+         (MissingMethodException: SkiaSharp.SKPathVerb Iterator.Next)。
+         7.8.0 は System.Drawing で描画するため SkiaSharp に依存しない。 -->
+    <PackageReference Include="FreeSpire.Presentation" Version="7.8.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.5.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="ShapeCrawler" Version="0.80.0" />
+    <!-- FreeSpire.Presentation 7.8.0 が引く 6.0.0 に脆弱性の指摘があるため明示的に上げる -->
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.11" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NantoNBai/NantoNBaiShapeCrawler.cs
+++ b/NantoNBai/NantoNBaiShapeCrawler.cs
@@ -1,6 +1,9 @@
-﻿using ShapeCrawler;
+﻿using DocumentFormat.OpenXml.Packaging;
+using ShapeCrawler;
 using System.IO;
 using System.Linq;
+using A = DocumentFormat.OpenXml.Drawing;
+using P = DocumentFormat.OpenXml.Presentation;
 
 namespace NantoNBai
 {
@@ -30,9 +33,45 @@ namespace NantoNBai
 
             var ms = new MemoryStream();
             pres.Save(ms);
+
+            ms.Position = 0;
+            RestoreInheritedTitleFormat(ms);
             ms.Position = 0;
 
             return ms;
+        }
+
+        // ShapeCrawler 0.80 はテキストを差し替えるときに、解決した書式を run に明示的に書き込む。
+        // その値がテンプレートの継承元 (マスターの titleStyle は 44pt、テーマの見出しフォント) と
+        // 一致せず、タイトルが 14pt の別フォントで描画されてしまう。
+        // ShapeCrawler の保存処理が書き込むため、保存後に明示書式を削って継承に戻す。
+        private static void RestoreInheritedTitleFormat(Stream pptx)
+        {
+            using var document = PresentationDocument.Open(pptx, true);
+            var slide = document.PresentationPart?.SlideParts.FirstOrDefault()?.Slide;
+            if (slide == null)
+            {
+                return;
+            }
+
+            var title = slide.Descendants<P.Shape>().FirstOrDefault(sp =>
+                sp.NonVisualShapeProperties?.ApplicationNonVisualDrawingProperties?.PlaceholderShape?.Type?.Value
+                    == P.PlaceholderValues.Title);
+            if (title == null)
+            {
+                return;
+            }
+
+            foreach (var properties in title.Descendants<A.RunProperties>().ToList())
+            {
+                properties.FontSize = null;
+                foreach (var child in properties.ChildElements
+                    .Where(c => c is A.LatinFont or A.EastAsianFont or A.ComplexScriptFont or A.SolidFill)
+                    .ToList())
+                {
+                    child.Remove();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## 症状

`NantoNBaiTests.GenerateImageTest` が `PixelErrorCount = 39842` で失敗する。
失敗した CI (run 32885320428) の成果物から `actual.png` を取り出して比較すると、退行は2つ。

| | expect.png | actual.png (現在) |
| --- | --- | --- |
| 評価透かし | なし | 上部に `Evaluation Warning : The document was created with Spire.Presentation for .NET` |
| タイトル | 44pt の見出しフォント | 14pt の本文フォント (数字も別フォント) |

どちらも #167 のパッケージ一括更新で入った。本番の出力画像も同じ状態になる。

## 原因と対処

### 1. 評価透かし = Free 版のライセンス表示

`FreeSpire.Presentation` 11.4.0 が変換後の画像に焼き込む。
テンプレートを一切編集せずに変換しても出るので、使い方では避けられない。

利用可能な Free 版で検証した結果:

| バージョン | 透かし | 併用可否 |
| --- | --- | --- |
| 11.4.0 | **入る** | ○ |
| 9.3.0 | 入らない | **✕** SkiaSharp 1.68 を要求し、ShapeCrawler が要求する SkiaSharp 4.x と実行時に衝突 (`MissingMethodException: SkiaSharp.SKPathVerb Iterator.Next`) |
| 7.8.0 | 入らない | ○ System.Drawing で描画するため SkiaSharp に依存しない |

→ **7.8.0 に戻す。** 画像保存も `image.Save(ms, ImageFormat.Png)` に戻す。
これは expect.png を生成した組み合わせでもある。

素朴な pptx をレンダリングする他の選択肢 (Aspose.Slides は有償、LibreOffice は
Consumption プランに入れられない、自前描画はオフィスソフトで作った見た目を捨てる) より、
この組み合わせが目的に合っている。

### 2. タイトルのフォント = ShapeCrawler が書式を上書きしていた

テンプレートのタイトルはプレースホルダーで、書式はマスターの `titleStyle` (44pt) と
テーマの見出しフォントから継承している。

ShapeCrawler 0.80 はテキストを差し替えるとき、解決した書式を run に明示的に書き込む:

```xml
<a:rPr lang="en-US" sz="1400" dirty="0">
  <a:solidFill><a:srgbClr val="000000"/></a:solidFill>
  <a:latin typeface="游ゴシック"/>
</a:rPr>
```

`sz="1400"` で 14pt に固定され、`<a:latin>` が数字 (`5倍` の `5`) のフォントも
テーマの見出しフォントから変えてしまう。
`SetText` / `TextBox.SetText` / `Paragraph.Text` / `Portion.Text` のどれでも同じ結果になり、
保存処理が書き込むため保存前に DOM をいじっても戻される。

→ **保存後にタイトルの run から `sz` / `latin` / `ea` / `cs` / `solidFill` を削除し、
テンプレートからの継承に戻す。** 書式の実体はテンプレート側に残る。

### その他

- 画像変換が System.Drawing (Windows 専用) を使うので、ライブラリのターゲットを
  `net10.0-windows` にする (`CA1416` の警告が出ていた)
- 7.8.0 が引く `System.Security.Cryptography.Pkcs` / `Xml` 6.0.0 に脆弱性の指摘があるため
  明示的に 10.0.11 へ上げる (`NU1903` / `NU1902` が出なくなる)

## 検証

Linux 上に .NET 10 SDK を入れて実測した (この環境には日本語フォントが無いので豆腐になるが、
透かしの有無とフォントサイズは確認できる)。

- 11.4.0 は編集していないテンプレートを変換しても透かしが入ることを確認
- 9.3.0 + ShapeCrawler 0.80 は `MissingMethodException` で落ちることを確認
- 修正後のライブラリで生成した pptx のタイトル run が `<a:rPr lang="en-US" dirty="0"/>` だけになり、
  レンダリングでタイトルが 44pt に戻ることを確認
- 生成処理がテンプレートファイルを書き換えていないことをハッシュで確認
- ビルドが `NU19xx` / `CA1416` 無しで通ることを確認

**ピクセル一致は Windows ランナーでしか確認できないので、この PR の CI が実際の合否です。**
残差が出た場合は 7.8.0 と ShapeCrawler 0.80 の組み合わせによる差分なので、
`actual.png` を確認して判断します。


---
_Generated by [Claude Code](https://claude.ai/code/session_011EwJ6ER5VASVsAr1ssJ9aN)_